### PR TITLE
Reduce default election time

### DIFF
--- a/contracts/eden/src/elections.cpp
+++ b/contracts/eden/src/elections.cpp
@@ -315,7 +315,7 @@ namespace eden
 
    void elections::set_next_election_time(eosio::time_point election_time)
    {
-      auto lock_time = eosio::current_time_point() + eosio::days(30);
+      auto lock_time = eosio::current_time_point() + eosio::days(7);
       eosio::check(election_time >= lock_time, "New election time is too close");
       uint8_t sequence = 1;
       if (state_sing.exists())
@@ -367,7 +367,7 @@ namespace eden
       uint16_t new_threshold = active_members + (active_members + 9) / 10;
       new_threshold = std::clamp(new_threshold, min_election_threshold, max_active_members);
       set_state_sing(current_election_state_registration_v1{
-          get_election_time(state.election_start_time, origin_time + eosio::days(180)),
+          get_election_time(state.election_start_time, origin_time + eosio::days(90)),
           new_threshold});
    }
 


### PR DESCRIPTION
## What does this PR do?
- Reduce the default election time from 180 to 90
- Set a minimum `lock_time` of 7 days instead of 30 days