### PR TITLE
Change from 7 days to 1 day to call the next election for the July el…

### DIFF
--- a/contracts/eden/src/elections.cpp
+++ b/contracts/eden/src/elections.cpp
@@ -318,9 +318,9 @@ namespace eden
       // TODO: The following block of code related to the July 2022 election should be removed in the next code update as it is only for a special scenario that occurs only once
       eosio::time_point_sec now = eosio::current_time_point();
       eosio::time_point_sec from_time = eosio::time_point_sec(1656547200);
-      eosio::time_point_sec to_time = eosio::time_point_sec(1656806400);
+      eosio::time_point_sec to_time = eosio::time_point_sec(1657324800);
       bool is_july_2022_election = from_time <= now && now < to_time;
-      auto lock_time = eosio::current_time_point() + eosio::days(!is_july_2022_election ? 30 : 7);
+      auto lock_time = eosio::current_time_point() + eosio::days(!is_july_2022_election ? 30 : 1);
       eosio::check(election_time >= lock_time, "New election time is too close");
       uint8_t sequence = 1;
       if (state_sing.exists())

--- a/contracts/eden/tests/test-eden.cpp
+++ b/contracts/eden/tests/test-eden.cpp
@@ -815,14 +815,16 @@ TEST_CASE("election rescheduled for July 2022")
 {
    eden_tester t;
    t.genesis();
+   t.eden_gm.act<actions::electsettime>(s2t("2022-06-01T13:00:00.000"));
    t.electdonate_all();
+   t.run_election();
    t.skip_to("2022-06-29T23:59:59.500");
    expect(t.eden_gm.trace<actions::electsettime>(s2t("2022-07-09T13:00:00.000")), "New election time is too close");
    t.skip_to("2022-06-30T00:00:00.000");
-   t.eden_gm.trace<actions::electsettime>(s2t("2022-07-09T13:00:00.000"));
-   t.skip_to("2022-07-02T23:59:59.500");
-   t.eden_gm.trace<actions::electsettime>(s2t("2022-07-09T13:00:00.000"));
-   t.skip_to("2022-07-03T00:00:00.000");
+   t.eden_gm.act<actions::electsettime>(s2t("2022-07-09T13:00:00.000"));
+   t.skip_to("2022-07-08T13:00:00.000");
+   t.eden_gm.act<actions::electsettime>(s2t("2022-07-09T13:00:00.000"));
+   t.skip_to("2022-07-09T00:00:00.000");
    expect(t.eden_gm.trace<actions::electsettime>(s2t("2022-07-09T13:00:00.000")), "New election time is too close");
 }
 


### PR DESCRIPTION
## What does this PR do?
- Change the required prior time to be able to call the July election from 7 days to 1 day
- Change `electsettime` restriction to be able to use the 1 day restriction prior the `Saturday, July 9, 2022 12:00:00 AM`