### PR TITLE
feat(portal): add eden smart proxy link in the footer

### DIFF
--- a/packages/webapp/src/_app/ui/footer.tsx
+++ b/packages/webapp/src/_app/ui/footer.tsx
@@ -85,6 +85,16 @@ export const Footer = () => (
                                 EdenOS Github Repo
                             </Link>
                         </li>
+                        <li>
+                            <Link
+                                className="text-gray-400"
+                                href="https://proxy.eden.eoscommunity.org"
+                                target="_blank"
+                                isExternal
+                            >
+                                Eden Smart Proxy
+                            </Link>
+                        </li>
                     </nav>
                 </div>
             </div>


### PR DESCRIPTION
## What does this PR do?
- add a new footer element (`Eden Smart Proxy`) pointing to the https://proxy.eden.eoscommunity.org link