### PR TITLE
perf(genesis.eden): add a flag to check if the funds have been returned

### DIFF
--- a/contracts/eden/src/distributions.cpp
+++ b/contracts/eden/src/distributions.cpp
@@ -504,6 +504,8 @@ namespace eden
 
    uint32_t distributions::on_collectfunds(uint32_t max_steps)
    {
+      uint32_t copy_max_steps = max_steps;
+      bool has_returned = false;
       auto months_to_withdraw = globals{contract}.get().max_month_withdraw;
 
       accounts owned_accounts{contract, "owned"_n};
@@ -525,6 +527,8 @@ namespace eden
                 contract);
             owned_accounts.add_balance("master"_n, iter->balance(), false);
             iter = distribution_account_tb.erase(iter);
+
+            has_returned = true;
          }
          else
          {
@@ -532,7 +536,7 @@ namespace eden
          }
       }
 
-      return max_steps;
+      return has_returned ? max_steps : copy_max_steps;
    }
 
    void distributions::clear_all()

--- a/contracts/eden/tests/test-eden.cpp
+++ b/contracts/eden/tests/test-eden.cpp
@@ -1537,6 +1537,8 @@ TEST_CASE("return funds to master by collecting them")
 
    // remove because the max time to collect the funds is 2 months
    t.egeon.act<actions::collectfunds>(100);
+   t.chain.start_block();
+   expect(t.egeon.trace<actions::collectfunds>(100), "Nothing to do");
    expected.erase(s2t("2020-04-04T15:30:00.000"));
    expected.erase(s2t("2020-05-04T15:30:00.000"));
    // validate funds are returned to master: 29.2734 EOS + 1.8000 EOS + 1.7100 EOS = 32.7834 EOS
@@ -1553,11 +1555,9 @@ TEST_CASE("return funds to master by collecting them")
 
    t.eden_gm.act<actions::setcoltime>(3);
    t.skip_to("2020-09-02T15:30:00.000");
-   t.egeon.act<actions::collectfunds>(100);
+   expect(t.egeon.trace<actions::collectfunds>(100), "Nothing to do");
    // no deletion is required since the max month to withdraw funds has changed to 90 days
-   expected[s2t("2020-09-02T15:30:00.000")] = s2a("1.6384 EOS");
-   CHECK(t.get_budgets_by_period() == expected);
-   CHECK(accounts{"eden.gm"_n, "owned"_n}.get_account("master"_n)->balance() == s2a("31.1304 EOS"));
+   // and no distribution is done since no funds to return are available
 }
 
 TEST_CASE("account migration")


### PR DESCRIPTION
## What does this PR do?
- update unit test to validate the `collectfunds` action fails when not funds have been returned
- add a flag in the `collectfunds` action to return the initial max_steps to indicate that no funds have been returned