### PR TITLE
perf(webapp): update home texts for not logged users

### DIFF
--- a/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
+++ b/packages/webapp/src/elections/components/registration-election-components/participation-card.tsx
@@ -109,7 +109,8 @@ export const ParticipationCard = ({ election }: Props) => {
     let statusButton = null;
 
     if (!ualAccount) {
-        participationCallLabel = "Sign in to participate.";
+        participationActionLabel = "I want to participate";
+        participationCallLabel = `Sign in to participate. You must choose "${participationActionLabel}" by ${electionParticipationLimitTime} to vote in the election.`;
         statusButton = (
             <Button onClick={ualShowModal}>Sign in to participate</Button>
         );


### PR DESCRIPTION
# What does this PR do?
- Update text in `main route` for not logged users

## New text
Sign in to participate. You must choose "I want to participate" by <election_time> to vote in the election.

## Old text
Sign in to participate.